### PR TITLE
[Phenotype page] - Switch layout and make changed based on Gene summary

### DIFF
--- a/components/Gene/Summary/index.tsx
+++ b/components/Gene/Summary/index.tsx
@@ -81,8 +81,8 @@ const Summary = ({ gene, numOfAlleles, loading, error }: SummaryProps) => {
       <Card>
         <div className={styles.subheadingCont}>
           <div className={styles.subheading}>
-            <span className={`${styles.subheadingSection} primary`}>Gene</span>
-            <span className={`${styles.subheadingSection}`}>
+            <span className={styles.subheadingSection}>Gene</span>
+            <span className={styles.subheadingSection}>
               {router.query.pid}
             </span>
           </div>
@@ -98,8 +98,8 @@ const Summary = ({ gene, numOfAlleles, loading, error }: SummaryProps) => {
       <Card>
         <div className={styles.subheadingCont}>
           <div className={styles.subheading}>
-            <span className={`${styles.subheadingSection} primary`}>Gene</span>
-            <span className={`${styles.subheadingSection}`}>
+            <span className={styles.subheadingSection}>Gene</span>
+            <span className={styles.subheadingSection}>
               {router.query.pid}
             </span>
           </div>

--- a/components/Phenotype/Summary/index.tsx
+++ b/components/Phenotype/Summary/index.tsx
@@ -50,8 +50,8 @@ const Summary = ({ phenotype, isLoading, isError }: Props) => {
       <Card>
         <div className={styles.subheadingCont}>
           <div className={styles.subheading}>
-            <span className={`${styles.subheadingSection} primary`}>Phenotype</span>
-            <span className={`${styles.subheadingSection}`}>
+            <span className={styles.subheadingSection}>Phenotype</span>
+            <span className={styles.subheadingSection}>
               {router.query.id}
             </span>
           </div>
@@ -67,8 +67,8 @@ const Summary = ({ phenotype, isLoading, isError }: Props) => {
       <Card>
         <div className={styles.subheadingCont}>
           <div className={styles.subheading}>
-            <span className={`${styles.subheadingSection} primary`}>Phenotype</span>
-            <span className={`${styles.subheadingSection}`}>
+            <span className={styles.subheadingSection}>Phenotype</span>
+            <span className={styles.subheadingSection}>
               {router.query.id}
             </span>
           </div>
@@ -88,7 +88,7 @@ const Summary = ({ phenotype, isLoading, isError }: Props) => {
     <Card>
       <div className={styles.subheadingCont}>
         <div className={styles.subheading}>
-          <span className={`${styles.subheadingSection} primary`}>
+          <span className={styles.subheadingSection}>
             Phenotype
           </span>
           {!!phenotype.phenotypeSynonyms?.length && (

--- a/components/Phenotype/Summary/styles.module.scss
+++ b/components/Phenotype/Summary/styles.module.scss
@@ -10,12 +10,14 @@
   letter-spacing: 0.1em;
   text-transform: uppercase;
   color: $grey;
+  font-size: 1.1rem;
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
+  gap: 1rem;
 }
 
 .subheadingSection {
-  margin-right: $md;
   display: inline-block;
   vertical-align: top;
 }

--- a/pages/phenotypes/[id].tsx
+++ b/pages/phenotypes/[id].tsx
@@ -37,12 +37,12 @@ const Phenotype = () => {
       <Search defaultType="phenotype" />
       <Container className="page">
         <Summary {...{ phenotype, isLoading, isError }}/>
-        <Card>
-          <h2>Genotype-phenotype associations</h2>
-          <ManhattanPlot phenotypeId={phenotypeId}  />
-        </Card>
         <Card id="associations-table">
           {!!phenotype && <Associations />}
+        </Card>
+        <Card>
+          <h2>Most significant associations for {phenotype?.phenotypeName}</h2>
+          <ManhattanPlot phenotypeId={phenotypeId}  />
         </Card>
         <Card>
           <h2>The way we measure</h2>

--- a/pages/phenotypes/[id].tsx
+++ b/pages/phenotypes/[id].tsx
@@ -38,7 +38,7 @@ const Phenotype = () => {
       <Container className="page">
         <Summary {...{ phenotype, isLoading, isError }}/>
         <Card id="associations-table">
-          {!!phenotype && <Associations />}
+          <Associations />
         </Card>
         <Card>
           <h2>Most significant associations for {phenotype?.phenotypeName}</h2>


### PR DESCRIPTION
- Switch positions between table and manhattan plot
- Avoid displaying empty section while loading associations table
- Update phenotype summary with changes similar to Gene summary