### PR TITLE
[Charts] - use same zygosity labels in charts and summary tables

### DIFF
--- a/components/Data/Categorical.tsx
+++ b/components/Data/Categorical.tsx
@@ -13,6 +13,7 @@ import { useQuery } from "@tanstack/react-query";
 import StatisticalAnalysisDownloadLink from "./StatisticalAnalysisDownloadLink";
 import { DownloadData } from "..";
 import { fetchDatasetFromS3 } from "@/api-service";
+import { getZygosityLabel } from "@/components/Data/Utils";
 
 const filterChartSeries = (zygosity: string, seriesArray: Array<any>) => {
   if (zygosity === "hemizygote") {
@@ -165,7 +166,7 @@ const Categorical = ({ datasetSummary, isVisible, children }: GeneralChartProps)
                 { width: 4, label: "Sample type / Category", disabled: true },
               ].concat(
                 data.dataBySex
-                  .map(({ sex, sampleGroup })  => `${capitalize(sex)} ${sampleGroup}`)
+                  .map(({ sex, sampleGroup })  => `${capitalize(sex)} ${getZygosityLabel(datasetSummary.zygosity, sampleGroup)}`)
                   .map((c) => {
                     return { width: 2, label: c, disabled: true };
                   })

--- a/components/Data/Plots/CategoricalBarPlot/index.tsx
+++ b/components/Data/Plots/CategoricalBarPlot/index.tsx
@@ -1,11 +1,5 @@
 import { Chart } from "react-chartjs-2";
-import {
-  CategoricalSeries,
-  bgColors,
-  borderColors,
-  shapes,
-  pointRadius,
-} from "..";
+import { CategoricalSeries, } from "..";
 
 import {
   Chart as ChartJS,
@@ -18,6 +12,8 @@ import {
   TimeScale,
   BarElement,
 } from "chart.js";
+import { getZygosityLabel } from "@/components/Data/Utils";
+import { capitalize } from "lodash";
 
 const colorArray = ["#D41159", "#0978a1", "#117733", "#44AA99", "#88CCEE", "#DDCC77", "#CC6677", "#AA4499"];
 
@@ -63,10 +59,8 @@ const CategoricalBarPlot = ({ series, zygosity }) => {
         datasets: Object.values(datasets),
         labels: series
           .map((s) => {
-            const labelSex = s.sex[0].toUpperCase() + s.sex.slice(1);
-            const labelZyg = zygosity === "homozygote" ? "HOM" : "HET";
-            const labelGroup =
-              s.sampleGroup == "experimental" ? labelZyg : "WT";
+            const labelSex = capitalize(s.sex);
+            const labelGroup = getZygosityLabel(zygosity, s.sampleGroup);
             return `${labelSex} ${labelGroup}`;
           })
           .filter((value, index, self) => self.indexOf(value) === index),

--- a/components/Data/Plots/UnidimensionalScatterPlot/index.tsx
+++ b/components/Data/Plots/UnidimensionalScatterPlot/index.tsx
@@ -8,12 +8,10 @@ import {
   Tooltip,
   TimeScale,
   ScatterController,
-  LineController,
+  LineController, LegendItem,
 } from "chart.js";
-
 import "chartjs-adapter-moment";
 import { FC } from "react";
-
 import { Chart } from "react-chartjs-2";
 import {
   bgColors,
@@ -22,6 +20,8 @@ import {
   shapes,
   UnidimensionalSeries,
 } from "..";
+import { getZygosityLabel } from "@/components/Data/Utils";
+import { capitalize } from "lodash";
 
 ChartJS.register(
   LinearScale,
@@ -45,13 +45,7 @@ interface IUnidimensionalScatterPlotProps {
 
 const getScatterDataset = (series: UnidimensionalSeries, zygosity) => {
   const labelSex = series.sex[0].toUpperCase() + series.sex.slice(1);
-  const labelZyg =
-    zygosity === "homozygote"
-      ? "HOM"
-      : zygosity === "hemizygote"
-      ? "HEM"
-      : "HET";
-  const labelGroup = series.sampleGroup == "experimental" ? labelZyg : "WT";
+  const labelGroup = getZygosityLabel(zygosity, series.sampleGroup);
   const order = labelGroup !== "WT" ? 1 : 2;
   const label = `${labelSex} ${labelGroup}`;
 
@@ -118,6 +112,16 @@ const UnidimensionalScatterPlot: FC<IUnidimensionalScatterPlotProps> = ({
             labels: {
               usePointStyle: true,
               padding: 20,
+              sort: (a: LegendItem, b: LegendItem) => {
+                if (
+                  a.text.includes("Female") && b.text.includes("Female") ||
+                  a.text.includes("Male") && b.text.includes("Male")
+                ) {
+                  return b.text.localeCompare(a.text);
+                } else {
+                  return a.text.localeCompare(b.text);
+                }
+              }
             },
           },
         },

--- a/components/Data/Unidimensional.tsx
+++ b/components/Data/Unidimensional.tsx
@@ -15,6 +15,7 @@ import { useQuery } from "@tanstack/react-query";
 import StatisticalAnalysisDownloadLink from "./StatisticalAnalysisDownloadLink";
 import { DownloadData } from "..";
 import { fetchDatasetFromS3 } from "@/api-service";
+import { getZygosityLabel } from "@/components/Data/Utils";
 
 type ChartSeries = {
   data: Array<any>;
@@ -73,9 +74,7 @@ const Unidimensional = ({ datasetSummary, isVisible, children }: GeneralChartPro
       const stddevKey = `${sex}${sampleGroupKey}Sd`;
       const countKey = `${sex}${sampleGroupKey}Count`;
       return {
-        label: `${capitalize(sex)} ${
-          sampleGroup === "control" ? "Control" : capitalize(zygosity)
-        }`,
+        label: `${capitalize(sex)} ${getZygosityLabel(zygosity, sampleGroup)}`,
         mean: datasetSummary.summaryStatistics?.[meanKey].toFixed(3) || 0,
         stddev: datasetSummary.summaryStatistics?.[stddevKey].toFixed(3) || 0,
         count: datasetSummary.summaryStatistics?.[countKey] || 0,

--- a/components/Data/Utils.tsx
+++ b/components/Data/Utils.tsx
@@ -11,6 +11,11 @@ import {
 } from "@/components/Data";
 import { ReactNode } from "react";
 
+
+export const getZygosityLabel = (zygosity: string, sampleGroup: string) => {
+  const labelZyg = zygosity === "hemizygote" ? 'HEM' : zygosity === "homozygote" ? "HOM" : "HET";
+  return sampleGroup == "control" ? "WT" : labelZyg;
+}
 export const getChartType = (
   datasetSummary: Dataset,
   isVisible: boolean = true,


### PR DESCRIPTION
- And order datasets in unidimensional scatter plot