### PR TITLE
Small updates

### DIFF
--- a/components/EmbryoDataAvailabilityGrid/index.tsx
+++ b/components/EmbryoDataAvailabilityGrid/index.tsx
@@ -117,13 +117,17 @@ const EmbryoDataAvailabilityGrid = ({
   const onClickTick = (cell: any) => {
     const geneAcc = geneIndex[cell.serieId];
     const dataType = cell.data.x;
+    // dont do anything if cell is empty
+    if (cell.value === 0) {
+      return;
+    }
     let url = "";
     if (
       ["OPT E9.5", "MicroCT E14.5-E15.5", "MicroCT E18.5"].includes(dataType)
     ) {
       url = `//www.mousephenotype.org/embryoviewer/?mgi=${geneAcc}`;
     } else if (dataType === "Vignettes") {
-      url = "/data/embryo/vignettes";
+      url = `/data/embryo/vignettes?gene=${cell.serieId}`;
     } else if (dataType === "LacZ") {
       url = `//www.mousephenotype.org/data/imageComparator?parameter_stable_id=IMPC_ELZ_064_001&acc=${geneAcc}`;
     } else {

--- a/components/Header/index.tsx
+++ b/components/Header/index.tsx
@@ -50,6 +50,8 @@ const getInternalLink = (name: string, link: string) => {
       return '/batch-query';
     case 'Late Adult Data':
       return '/late-adult-data';
+    case 'Latest Data Release':
+      return '/release';
     default:
       return link;
   }

--- a/pages/embryo/index.tsx
+++ b/pages/embryo/index.tsx
@@ -12,7 +12,7 @@ import Head from "next/head";
 import { capitalize } from "lodash";
 import { useEmbryoLandingQuery } from "@/hooks";
 import { useMemo, useState } from "react";
-import { PlainTextCell, SmartTable } from "@/components/SmartTable";
+import { LinkCell, PlainTextCell, SmartTable } from "@/components/SmartTable";
 import Link from "next/link";
 
 const PublicationsList = dynamic<PublicationListProps>(
@@ -419,7 +419,7 @@ const EmbryoLandingPage = () => {
               defaultSort={[ "geneSymbol", "asc" ]}
               columns={[
                 { width: 1, label: "Gene symbol", field: "geneSymbol", cmp: <PlainTextCell/> },
-                { width: 1, label: "MGI Accession ID", field: "mgiGeneAccessionId", disabled: true, cmp: <PlainTextCell/> },
+                { width: 1, label: "MGI Accession ID", field: "mgiGeneAccessionId", disabled: true, cmp: <LinkCell prefix="/genes"/> },
               ]}
               paginationButtonsPlacement="bottom"
               displayPageControls={false}

--- a/pages/embryo/vignettes.tsx
+++ b/pages/embryo/vignettes.tsx
@@ -5,7 +5,8 @@ import Link from "next/link";
 import Slider from "react-slick";
 import "slick-carousel/slick/slick.css";
 import "slick-carousel/slick/slick-theme.css";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
+import { useRouter } from "next/router";
 
 const additionalContentMap = {
   "cbx4_thymus_black.png": "Whole structural volume differences calculated as a percentage of whole body volume for the left and right thymic rudiment (left) and left and right adrenal (right) of Cbx4<sup>tm1.1/tm1.1</sup> mutant embryos compared to Cbx4<sup>+/+</sup> wildtype embryos. Both organs are significantly smaller in the Cbx4 mutant embryos at an FDR threshold of 5% where the error bars represent 95% confidence intervals.",
@@ -17,8 +18,41 @@ const additionalContentMap = {
   "Tmem132a axial.png": "Axial images from microCT volumes of wildtype (WT) and mutant (Tmem132a<sup>tm1b/tm1b</sup>) showing kidney abnormalities (extra lobe)."
 };
 
+const genePositions = {
+  'Chtop': 0,
+  'Klhdc2': 1,
+  'Acvr2a': 2,
+  'Cbx4': 3,
+  'Tmem100': 4,
+  'Eya4': 5,
+  'Tox3': 6,
+  'Rsph9': 7,
+  'Pax7': 8,
+  'Svep1': 9,
+  'Strn3': 10,
+  'Rab34': 11,
+  'Cox7c': 12,
+  'Bloc1s2': 13,
+  'Gfpt1': 14,
+  'Atg3': 15,
+  'Kdm8': 16,
+  'Slc39a8': 17,
+  'Gyg1': 18,
+  'Tmem132a': 19,
+}
+
 const EmbryoVignettesPage = () => {
+  const router = useRouter();
+  const slickRef = useRef(null);
   const [selectedFile, setSelectedFile] = useState<string>(undefined);
+  const [navigatedToGene, setNavigatedToGene] = useState<boolean>(false);
+
+  useEffect(() => {
+    if (!!router.query.gene && slickRef.current && !navigatedToGene) {
+      slickRef.current.slickGoTo(genePositions[router.query.gene as string]);
+      setNavigatedToGene(true);
+    }
+  }, [router.isReady, slickRef]);
 
   return (
     <>
@@ -64,6 +98,7 @@ const EmbryoVignettesPage = () => {
               slidesToShow={1}
               slidesToScroll={1}
               adaptiveHeight
+              ref={slickRef}
             >
               <div className="vignette">
                 <Row>
@@ -1111,7 +1146,7 @@ const EmbryoVignettesPage = () => {
               </div>
               <div className="vignette">
                 <Row>
-                  <h1><strong>Gyg<sup>tm1b(KOMP)Wtsi</sup></strong></h1>
+                  <h1><strong>Gyg1<sup>tm1b(KOMP)Wtsi</sup></strong></h1>
                   <Col xs={8}>
                     <p>
                       Glycogenin is an enzyme that converts glucose to glycogen.

--- a/pages/release.tsx
+++ b/pages/release.tsx
@@ -73,8 +73,8 @@ type ReleaseMetadata = {
   sampleCounts: Array<SampleCounts>;
 };
 
-const valuePair = (key: string, value: string | number) => (
-  <div>
+const valuePair = (key: string, value: string | number, enableJustify: boolean = false) => (
+  <div style={enableJustify ? { display: "grid", gridTemplateColumns: "1fr 1fr" } : {}}>
     <span className="grey">{key}: </span>
     {typeof value === 'number' ? (
       <strong>{value.toLocaleString()}</strong>
@@ -328,9 +328,9 @@ const ReleaseNotesPage = (props: Props) => {
           <Row className="mb-4">
             <Col lg={6}>
               <h3 className="mb-0 mt-3 mb-2">Summary</h3>
-              {valuePair("Number of phenotyped genes", releaseMetadata.summaryCounts.phenotypedGenes)}
-              {valuePair("Number of phenotyped mutant lines", releaseMetadata.summaryCounts.phenotypedLines)}
-              {valuePair("Number of phenotype calls", releaseMetadata.summaryCounts.phentoypeCalls)}
+              {valuePair("Number of phenotyped genes", releaseMetadata.summaryCounts.phenotypedGenes, true)}
+              {valuePair("Number of phenotyped mutant lines", releaseMetadata.summaryCounts.phenotypedLines, true)}
+              {valuePair("Number of phenotype calls", releaseMetadata.summaryCounts.phentoypeCalls, true)}
             </Col>
             <Col lg={6}>
               <h3 className="mb-0 mt-3 mb-2">Data access</h3>


### PR DESCRIPTION
- right-justify numbers in release summary section
- secondary viability modal, add links to id column
- when navigating to gene embryo vignette page from embryo landing heatmap, show selected gene in view