### PR TITLE
[Data comparison and Sig phenotypes table] Fix: Combined pValues and ensure significance of data

### DIFF
--- a/components/Data/DataComparison/utils.ts
+++ b/components/Data/DataComparison/utils.ts
@@ -56,11 +56,14 @@ export const groupData = (data) => {
     }
     if (
       !sex &&
-      (d.statisticalMethod?.attributes?.genotypeEffectPValue !== null ||
-        d.statisticalMethod?.attributes.genotypeEffectPValue !== undefined)
+      d.statisticalMethod?.attributes?.genotypeEffectPValue !== null &&
+      d.statisticalMethod?.attributes.genotypeEffectPValue !== undefined
     ) {
       acc[key][`pValue_not_considered`] =
         d.statisticalMethod?.attributes?.genotypeEffectPValue;
+    }
+    if (!sex && reportedPValue !== null && reportedPValue !== undefined) {
+      acc[key][`pValue_not_considered`] = reportedPValue;
     }
     return acc;
   }, {});

--- a/shared/hooks/significant-phenotypes.query.ts
+++ b/shared/hooks/significant-phenotypes.query.ts
@@ -2,6 +2,8 @@ import { useQuery } from "@tanstack/react-query";
 import { fetchAPI } from "@/api-service";
 import { GenePhenotypeHits } from "@/models/gene";
 
+const ABRProcedures = ["IMPC_ACS_001", "IMPC_ACS_002", "IMPC_ACS_003"];
+
 const PPIParameters = [
   "PPI1", // % PP1
   "PPI2", // % PP2
@@ -50,10 +52,11 @@ export const processGenePhenotypeHitsResponse = (
       };
     } else if (group[key].datasetId !== datasetId) {
       // check for PPI related parameters and only count the PPI1, PPI2, PPI3 and PPI4
-      if (group[key].procedureStableId === "IMPC_ACS_003") {
-        if (PPIParameters.some((param) => item.parameterName.includes(param))) {
-          group[key].datasetsIds.push(datasetId);
-        }
+      if (
+        ABRProcedures.includes(group[key].procedureStableId) &&
+        PPIParameters.some((param) => item.parameterName.includes(param))
+      ) {
+        group[key].datasetsIds.push(datasetId);
       } else if (!group[key].datasetsIds.includes(datasetId)) {
         group[key].datasetsIds.push(datasetId);
       }

--- a/shared/hooks/significant-phenotypes.query.ts
+++ b/shared/hooks/significant-phenotypes.query.ts
@@ -14,7 +14,8 @@ export const processGenePhenotypeHitsResponse = (
 ) => {
   const group: Record<string, GenePhenotypeHits> = {};
   const significantData = data.filter(
-    (phenotypeHit) => phenotypeHit.pValue < 0.0001
+    (phenotypeHit) =>
+      phenotypeHit.pValue < 0.0001 || phenotypeHit.assertionType === "manual"
   );
   significantData.forEach((item) => {
     const {

--- a/shared/hooks/significant-phenotypes.query.ts
+++ b/shared/hooks/significant-phenotypes.query.ts
@@ -13,7 +13,10 @@ export const processGenePhenotypeHitsResponse = (
   data: Array<GenePhenotypeHits>
 ) => {
   const group: Record<string, GenePhenotypeHits> = {};
-  data.forEach((item) => {
+  const significantData = data.filter(
+    (phenotypeHit) => phenotypeHit.pValue < 0.0001
+  );
+  significantData.forEach((item) => {
     const {
       datasetId,
       phenotype: { id },


### PR DESCRIPTION
- fix: handle scenarios when datasets have sex === null and statisticalMethod attributes genotypeEffectPValue is null, set pValue_not_considered to reportedPValue
- ensure sig phenotypes data significance by filtering pValues above threshold or if assertionType == manual
- improve datasets counting for PPI, check for multiple procedureStableIds 