### PR TITLE
[Sig phenotypes table] Handle topLevelPhenotypes null case

### DIFF
--- a/components/Gene/Phenotypes/SignificantPhenotypes/index.tsx
+++ b/components/Gene/Phenotypes/SignificantPhenotypes/index.tsx
@@ -49,7 +49,7 @@ const SignificantPhenotypes = ({
     phenotypeData.map((phenotype) => phenotype.alleleSymbol)
   );
   const systems = uniq(
-    phenotypeData.flatMap((p) => p.topLevelPhenotypes.map((tl) => tl.name))
+    phenotypeData.flatMap((p) => p.topLevelPhenotypes?.map((tl) => tl.name))
   );
   const lifeStages = uniq(phenotypeData.map((p) => p.lifeStageName));
   const zygosities = uniq(phenotypeData.map((p) => p.zygosity));

--- a/shared/hooks/significant-phenotypes.query.ts
+++ b/shared/hooks/significant-phenotypes.query.ts
@@ -17,7 +17,9 @@ export const processGenePhenotypeHitsResponse = (
   const group: Record<string, GenePhenotypeHits> = {};
   const significantData = data.filter(
     (phenotypeHit) =>
-      phenotypeHit.pValue < 0.0001 || phenotypeHit.assertionType === "manual"
+      (phenotypeHit.pValue < 0.0001 ||
+        phenotypeHit.assertionType === "manual") &&
+      !!phenotypeHit.phenotype.id
   );
   significantData.forEach((item) => {
     const {


### PR DESCRIPTION
And filter out phenotype hits that doesn't have phenotype id (link to supporting data broken) 