### PR TITLE
fix: removes htmlEncode function for phenogrid

### DIFF
--- a/components/Gene/HumanDiseases/index.tsx
+++ b/components/Gene/HumanDiseases/index.tsx
@@ -17,7 +17,7 @@ import { fetchAPI } from "@/api-service";
 import { GeneDisease } from "@/models/gene";
 import { sectionWithErrorBoundary } from "@/hoc/sectionWithErrorBoundary";
 import { DownloadData, SectionHeader } from "@/components";
-import { isIframeLoaded, htmlEncode } from "@/utils";
+import { isIframeLoaded } from "@/utils";
 import { SortType } from "@/models";
 
 type ScaleProps = {
@@ -69,8 +69,7 @@ const PhenoGridEl = ({ rowDiseasePhenotypes, data }) => {
     .filter(({ phenodigmScore }) => phenodigmScore > 0)
     .map(({ modelPhenotypes, modelDescription, phenodigmScore }) => {
       const mousePhenotypes = processPhenotypes(modelPhenotypes.join());
-      // send HTML encode the id to get correct labels in tooltip. Downside: the labels on top are not readable.
-      const id = htmlEncode(modelDescription);
+      const id = modelDescription;
       const label = `${phenodigmScore.toFixed(2)}-${id}`;
       const phenotypes = mousePhenotypes.map((item) => item.id);
 

--- a/utils/index.tsx
+++ b/utils/index.tsx
@@ -440,8 +440,3 @@ export const isIframeLoaded = (iframe: HTMLIFrameElement) => {
     iframe.addEventListener("error", () => reject("Error loading iframe"));
   });
 };
-
-// Generic htmlEncoder
-export const htmlEncode = (id: string) => {
-  return id.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
-};


### PR DESCRIPTION
## Context
Monarch App update [v1.10.0 ](https://github.com/monarch-initiative/monarch-app/tree/v1.10.0) fixed the following phenogrid issues:
1. [Encoding of labels in phenogrid](https://github.com/monarch-initiative/monarch-app/pull/908)
2. [Phenogrid cell labels](https://github.com/monarch-initiative/monarch-app/pull/892)
3.  [Out of frame phenogrid](https://github.com/monarch-initiative/monarch-app/pull/891). This was bug introduced after v1.9.0.

## Fix
The current change removes the encoding that was placed as a temporary measure for the first issue.

This measure allowed to pass special characters from mouse models ("<", ">", "&") into the tooltips of the Phenogrid without losing information. The downside was the labels on the x-axis would display the characters instead of the formatted mouse model description. 

With the changes from Monarch, encoding is no longer necessary. 



