### PR TITLE
Fix: Missing values in Categorical chart bar

### DIFF
--- a/components/Data/Plots/CategoricalBarPlot/index.tsx
+++ b/components/Data/Plots/CategoricalBarPlot/index.tsx
@@ -101,6 +101,14 @@ const CategoricalBarPlot = ({ series, zygosity }) => {
               padding: 20,
             },
           },
+          tooltip: {
+            callbacks: {
+              label: (context) => {
+                let label = context.dataset.label || "";
+                return `${label}: ${context.parsed.y?.toFixed(2)}%`;
+              },
+            },
+          },
         },
         scales: {
           y: {

--- a/components/Data/Plots/CategoricalBarPlot/index.tsx
+++ b/components/Data/Plots/CategoricalBarPlot/index.tsx
@@ -1,5 +1,5 @@
 import { Chart } from "react-chartjs-2";
-import { CategoricalSeries, } from "..";
+import { CategoricalSeries } from "..";
 
 import {
   Chart as ChartJS,
@@ -13,9 +13,18 @@ import {
   BarElement,
 } from "chart.js";
 import { getZygosityLabel } from "@/components/Data/Utils";
-import { capitalize } from "lodash";
+import { capitalize, uniq } from "lodash";
 
-const colorArray = ["#D41159", "#0978a1", "#117733", "#44AA99", "#88CCEE", "#DDCC77", "#CC6677", "#AA4499"];
+const colorArray = [
+  "#D41159",
+  "#0978a1",
+  "#117733",
+  "#44AA99",
+  "#88CCEE",
+  "#DDCC77",
+  "#CC6677",
+  "#AA4499",
+];
 
 ChartJS.register(
   LinearScale,
@@ -28,27 +37,48 @@ ChartJS.register(
   CategoryScale
 );
 
+const getChartLabel = (series: CategoricalSeries, zygosity) => {
+  const labelSex = capitalize(series.sex);
+  const labelGroup = getZygosityLabel(zygosity, series.sampleGroup);
+  return `${labelSex} ${labelGroup}`;
+};
+
 const getCategoricalBarDataset = (
   series: CategoricalSeries,
   zygosity,
-  categories
+  categories,
+  labels: Array<string>
 ) => {
-  return {
+  const dataset = {
     backgroundColor: colorArray[categories.indexOf(series.category)],
     label: series.category,
     stack: "0",
-    data: [series.value],
+    data: labels.map(() => 0),
   };
+  const seriesLabel = getChartLabel(series, zygosity);
+  const labelPos = labels.findIndex((label) => label === seriesLabel);
+  dataset.data.splice(labelPos, 1, series.value);
+  return dataset;
 };
 
 const CategoricalBarPlot = ({ series, zygosity }) => {
   const datasets = {};
   const categories = series.map((s) => s.category);
+  const labels: Array<string> = uniq(
+    series.map((s) => getChartLabel(s, zygosity))
+  );
   series.forEach((s) => {
     if (!datasets[s.category]) {
-      datasets[s.category] = getCategoricalBarDataset(s, zygosity, categories);
+      datasets[s.category] = getCategoricalBarDataset(
+        s,
+        zygosity,
+        categories,
+        labels
+      );
     } else {
-      datasets[s.category].data.push(s.value);
+      const seriesLabel = getChartLabel(s, zygosity);
+      const labelPos = labels.findIndex((label) => label === seriesLabel);
+      datasets[s.category].data.splice(labelPos, 1, s.value);
     }
   });
 
@@ -57,13 +87,9 @@ const CategoricalBarPlot = ({ series, zygosity }) => {
       type="bar"
       data={{
         datasets: Object.values(datasets),
-        labels: series
-          .map((s) => {
-            const labelSex = capitalize(s.sex);
-            const labelGroup = getZygosityLabel(zygosity, s.sampleGroup);
-            return `${labelSex} ${labelGroup}`;
-          })
-          .filter((value, index, self) => self.indexOf(value) === index),
+        labels: labels.filter(
+          (value, index, self) => self.indexOf(value) === index
+        ),
       }}
       options={{
         maintainAspectRatio: true,


### PR DESCRIPTION
Add default values for all datasets data arrays in the Categorical chart bar and replaced values of each series