### PR TITLE
[Allele page]: Add alleleSymbol query param

### DIFF
--- a/app/alleles/[pid]/[...alleleSymbol]/allele-page.tsx
+++ b/app/alleles/[pid]/[...alleleSymbol]/allele-page.tsx
@@ -65,12 +65,9 @@ const ProductItem = ({
   </div>
 );
 
-const AllelePage = ({ alleleData: alleleFromServer }) => {
+const AllelePage = ({ alleleData: alleleFromServer, alleleSymbol }) => {
   const params = useParams<{ pid: string; alleleSymbol: Array<string> }>();
   const pid = decodeURIComponent(params.pid);
-  const alleleSymbolParsed = params.alleleSymbol;
-
-  const alleleSymbol = (alleleSymbolParsed as Array<string>).join("/");
 
   const { data: allele } = useQuery<AlleleSummary>({
     queryKey: ["genes", pid, "alleles", alleleSymbol, "order"],

--- a/app/alleles/[pid]/[...alleleSymbol]/page.tsx
+++ b/app/alleles/[pid]/[...alleleSymbol]/page.tsx
@@ -27,18 +27,27 @@ type PageParams = {
     pid: string;
     alleleSymbol: Array<string>;
   }>;
+  searchParams: { alleleSymbol: string };
 };
 
-export default async function Page({ params }: PageParams) {
+export default async function Page({ params, searchParams }: PageParams) {
   const mgiGeneAccessionId = (await params).pid;
-  const alleleSymbol = (await params).alleleSymbol;
+  const alleleSymbolFromParams = (await params).alleleSymbol;
+  const alleleSymbolFromSearchParams = searchParams.alleleSymbol;
+  const alleleSymbol = !!alleleSymbolFromSearchParams
+    ? [alleleSymbolFromSearchParams]
+    : alleleSymbolFromParams;
   const alleleData = await getAlleleSummary(mgiGeneAccessionId, alleleSymbol);
-  return <AllelePage alleleData={alleleData} />;
+  return <AllelePage alleleData={alleleData} alleleSymbol={alleleSymbol} />;
 }
 
-export async function generateMetadata({ params }: PageParams) {
+export async function generateMetadata({ params, searchParams }: PageParams) {
   const mgiGeneAccessionId = (await params).pid;
-  const alleleSymbol = (await params).alleleSymbol;
+  const alleleSymbolFromParams = (await params).alleleSymbol;
+  const alleleSymbolFromSearchParams = searchParams.alleleSymbol;
+  const alleleSymbol = !!alleleSymbolFromSearchParams
+    ? [alleleSymbolFromSearchParams]
+    : alleleSymbolFromParams;
   const alleleData = await getAlleleSummary(mgiGeneAccessionId, alleleSymbol);
   const { alleleName, geneSymbol } = alleleData;
   const title = `${alleleName} allele of ${geneSymbol} mouse gene | IMPC`;

--- a/app/alleles/[pid]/[...alleleSymbol]/page.tsx
+++ b/app/alleles/[pid]/[...alleleSymbol]/page.tsx
@@ -8,7 +8,7 @@ async function getAlleleSummary(
   mgiGeneAccessionId: string,
   alleleSymbol: Array<string>,
 ) {
-  const parsedAllele = alleleSymbol.join("/");
+  const parsedAllele = decodeURIComponent(alleleSymbol.join("/"));
   if (!mgiGeneAccessionId || mgiGeneAccessionId === "null" || !alleleSymbol) {
     notFound();
   }

--- a/components/Gene/Order/index.tsx
+++ b/components/Gene/Order/index.tsx
@@ -51,8 +51,8 @@ const Order = ({
       "ES Cell": "esCell",
       "targeting vector": "targetingVector",
     };
-    const encodedAllele = allele;
-    return `/alleles/${gene.mgiGeneAccessionId}/${encodedAllele}#${anchorObjs[product]}`;
+    const encodedAllele = encodeURIComponent(allele);
+    return `/alleles/${gene.mgiGeneAccessionId}/${encodedAllele}?alleleSymbol=${allele}#${anchorObjs[product]}`;
   };
 
   const orderData = orderDataFromServer || filtered;


### PR DESCRIPTION
Use new query param to fetch data and fallback to url if not present.
Add the new param to the Order section links.