### PR TITLE
[Genome Browser] - Fix search service config

### DIFF
--- a/components/GenomeBrowser/GenomeBrowser.tsx
+++ b/components/GenomeBrowser/GenomeBrowser.tsx
@@ -152,6 +152,7 @@ const GenomeBrowser = ({
         search: {
           url: "https://www.gentar.org/orthology-api/api/ortholog/get-coordinates/search?geneQuery=$FEATURE$",
           resultsField: "results",
+          endField: "stop",
         },
         tracks,
       };


### PR DESCRIPTION
fix: add missing endField to parse properly results from GenTar service