### PR TITLE
[Chart pages] - add extra filter parameters, alleleAccessionId and lifeStageName

### DIFF
--- a/app/supporting-data/supporting-data-page.tsx
+++ b/app/supporting-data/supporting-data-page.tsx
@@ -38,6 +38,7 @@ const generateParamsObject = (
     "pipelineStableId",
     "procedureStableId",
     "phenotypingCentre",
+    "lifeStageName",
   ];
   const result = {};
   params.forEach((param) => (result[param] = searchParams.get(param)));

--- a/components/Gene/Phenotypes/SignificantPhenotypes/custom-cells.tsx
+++ b/components/Gene/Phenotypes/SignificantPhenotypes/custom-cells.tsx
@@ -9,10 +9,12 @@ export const SupportingDataCell = <T,>(props: Props<T>) => {
   const numOfDatasets = get(props.value, props.field)?.length;
   const mgiAccessionId = get(props.value, "mgiGeneAccessionId") as string;
   const phenotypeName = get(props.value, "phenotypeName") as string;
+  const alleleAccessionId = get(props.value, "alleleAccessionId") as string;
+  const lifeStage = get(props.value, "lifeStageName") as string;
   const mpTermKey = !!props.mpTermIdKey ? props.mpTermIdKey : "id";
   const mpTermpId = get(props.value, mpTermKey) as string;
 
-  let url = `/supporting-data?mgiGeneAccessionId=${mgiAccessionId}&mpTermId=${mpTermpId}`;
+  let url = `/supporting-data?mgiGeneAccessionId=${mgiAccessionId}&mpTermId=${mpTermpId}&alleleAccessionId=${alleleAccessionId}&lifeStageName=${lifeStage}`;
   const isAssociatedToPWG = props.value?.["projectName"] === "PWG" || false;
   if (isAssociatedToPWG) {
     url =

--- a/shared/hooks/datasets.query.ts
+++ b/shared/hooks/datasets.query.ts
@@ -8,7 +8,7 @@ export const generateDatasetsEndpointUrl = (
   params: ChartPageParamsObj,
 ) => {
   let endpointUrl = !!params.mpTermId
-    ? `/api/v1/genes/${mgiGeneAccessionId}/${params.mpTermId}/dataset/`
+    ? `/api/v1/genes/${mgiGeneAccessionId}/${params.mpTermId}/dataset?alleleAccessionId=${params.alleleAccessionId}&lifeStageName=${params.lifeStageName}`
     : `/api/v1/genes/dataset/find_by_multiple_parameter?mgiGeneAccessionId=${mgiGeneAccessionId}&alleleAccessionId=${params.alleleAccessionId}&zygosity=${params.zygosity}&parameterStableId=${params.parameterStableId}&pipelineStableId=${params.pipelineStableId}&procedureStableId=${params.procedureStableId}&phenotypingCentre=${params.phenotypingCentre}`;
   if (!params.mpTermId && !!params.metadataGroup) {
     endpointUrl += `&metadataGroup=${params.metadataGroup}`;

--- a/shared/models/chart.ts
+++ b/shared/models/chart.ts
@@ -39,6 +39,7 @@ export type ChartPageParams =
   | "pipelineStableId"
   | "procedureStableId"
   | "phenotypingCentre"
-  | "metadataGroup";
+  | "metadataGroup"
+  | "lifeStageName";
 
 export type ChartPageParamsObj = Record<ChartPageParams, string>;


### PR DESCRIPTION
When navigating to a chart page from the significant phenotypes table