### PR TITLE
fix:fullData to concatenate data even when associatedDiseases is empty

### DIFF
--- a/components/Gene/HumanDiseases/index.tsx
+++ b/components/Gene/HumanDiseases/index.tsx
@@ -356,7 +356,7 @@ const HumanDiseases = ({ initialData }: HumanDiseasesProps) => {
   const [tab, setTab] = useState("associated");
 
   const fullData = useMemo(
-    () => associatedDiseases?.concat(predictedDiseases ?? []) ?? [],
+    () => (associatedDiseases ?? []).concat(predictedDiseases ?? []) ?? [],
     [associatedDiseases, predictedDiseases],
   );
 


### PR DESCRIPTION
## Context
The Phenogrid was not loading in genes where there were only predicted diseases. The root of the issue was `fullData` which concatenates data for associated and predicted diseases. Before, if `associatedDiseases` was null/undefined, the value of `fullData` would have been undefined too, causing no data (objectSets) to be sent to the Monarch even if there were `predictedDiseases`. 

## Solution
This changes the behaviour to concatenate `predictedDiseases` even if `associatedDiseases` is undefined.